### PR TITLE
Mesh conversion: define intermediate prim as Scope

### DIFF
--- a/src/sdf_parser/Geometry.cc
+++ b/src/sdf_parser/Geometry.cc
@@ -45,6 +45,7 @@
 #include <pxr/usd/usdGeom/primvarsAPI.h>
 #include <pxr/usd/usdGeom/primvar.h>
 #include <pxr/usd/usdGeom/mesh.h>
+#include <pxr/usd/usdGeom/scope.h>
 #include <pxr/usd/usdGeom/sphere.h>
 #include <pxr/usd/usdGeom/xform.h>
 #include <pxr/usd/usdGeom/xformCommonAPI.h>
@@ -396,6 +397,19 @@ namespace usd
       // this case is "verticesPerFace"
       for (unsigned int n = 0; n < numFaces; ++n)
         faceVertexCounts.push_back(verticesPerFace);
+
+      // The other geometry types in this file create a prim at _path,
+      // but in order to store the mesh name in USD, an additional level
+      // is added to the USD hierarchy with the mesh name.
+      // To ensure that the prim at _path has a type, define it as a Scope.
+      auto usdScope = pxr::UsdGeomScope::Define(_stage, pxr::SdfPath(_path));
+      if (!usdScope)
+      {
+        errors.push_back(UsdError(
+          gz::usd::UsdErrorCode::FAILED_USD_DEFINITION,
+          "Unable to define a USD geometry scope at path [" + _path + "]"));
+        return errors;
+      }
 
       std::string primName;
       if (!subMesh->Name().empty())


### PR DESCRIPTION
# 🦟 Bug fix



## Summary

When converting parsing a mesh from SDFormat, an extra level of USD hierarchy is added with the mesh name. To ensure all prims have a type, define the intermediate prim type as a Scope, as recommended by a USD expert.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
