### PR TITLE
sdf2usd: set cylinder refinement parameter

### DIFF
--- a/src/sdf_parser/Geometry.cc
+++ b/src/sdf_parser/Geometry.cc
@@ -195,6 +195,19 @@ namespace usd
     extentBounds.push_back(endPoint);
     usdCylinder.CreateExtentAttr().Set(extentBounds);
 
+    // Set refinement level for cylinders so that the visual shapes will look
+    // rounder. It should be ignored for collision shapes.
+    auto enableRefinementAttr =
+        usdCylinder.GetPrim().CreateAttribute(
+            pxr::TfToken("refinementEnableOverride"),
+            pxr::SdfValueTypeNames->Bool, false);
+    enableRefinementAttr.Set(true);
+    auto refinementAttr =
+        usdCylinder.GetPrim().CreateAttribute(
+            pxr::TfToken("refinementLevel"),
+            pxr::SdfValueTypeNames->Int, false);
+    refinementAttr.Set(1);
+
     return errors;
   }
 


### PR DESCRIPTION
# 🦟 Bug fix



## Summary

The refinement parameter is 0 by default when loaded in Isaac Sim, which makes cylinders look like extruded polygons. Setting the refinement parameter to 1 makes them rounder.

Thanks to @rgasoto for the assistance with the OpenUSD API.

### Example with unrefined cylinders

Note the polygonal shape of the pendulum bases

![cylinders_refinement_0](https://github.com/user-attachments/assets/16db7dfb-0a20-46cc-b538-3804e2da5e2e)

### Example with refinement == 1

Note the rounder shape of the pendulum bases

![cylinders_refinement_1](https://github.com/user-attachments/assets/c48f38a8-04a3-4fa2-acdd-7fd3d4a13d8d)


## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
